### PR TITLE
Remove dpi from pictures sizes specified in px

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
               <p class="text-small">
                 <i class="fab fa-creative-commons"></i>
                 <i class="fab fa-creative-commons-by"></i>
-                | Tamaño: 1600x1000 px (300 ppp)
+                | Tamaño: 1600x1000 px
               </p>
               <p class="text-small">
                 <i class="fas fa-file-download"></i>
@@ -115,7 +115,7 @@
               <p class="text-small">
                 <i class="fab fa-creative-commons"></i>
                 <i class="fab fa-creative-commons-by"></i>
-                | Tamaño: 2250x1688 px (96 ppp)
+                | Tamaño: 2250x1688 px
               </p>
               <p class="text-small">
                 <i class="fas fa-file-download"></i>


### PR DESCRIPTION
If the size of the picture is given in pixels, there's no point in setting the dpi.